### PR TITLE
Improvements to pasting logic

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""Stores and make possible the entry of frequently used blocks of text. Command: Windows+F12."""),
 	# version
-	"addon_version" : "1.0",
+	"addon_version" : "1.1",
 	# Author(s)
 	"addon_author" : u"Rui Fontes <rui.fontes@tiflotecnia.com> and Ângelo Abrantes <ampa4374@gmail.com>",
 	# URL for the add-on documentation support


### PR DESCRIPTION
Hi, thanks for this very useful add-on!
I propose a few minor changes to onPaste function:
1. Control+V doesn't seem to work for pasting in command line window - so I wrote an alternative way to make it to work.
2. The state of clipboard is restored immediately after pasting.
3. All lines are now pasted as a single chunk of text.
4. (if you don't mind) for single line pasting I propose not to insert a newline character in the end. The reason for that is that I often paste things in command line or single-line text box, where pressing return either executes command, or does something that cannot be easily undone.
Thanks!
